### PR TITLE
Code cleanup (filename variable)

### DIFF
--- a/Libra-Office-Auto-Installer(Run In Admin).ps1
+++ b/Libra-Office-Auto-Installer(Run In Admin).ps1
@@ -21,6 +21,9 @@ if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
 # Define URLs for software installers
 $LibreOfficeURL = 'https://tdf.mirror.garr.it/libreoffice/stable/24.8.0/win/x86_64/LibreOffice_24.8.0_Win_x86-64.msi'
 
+# Store LibreOffice URL basename in variable
+$LibreOfficeFILE = Split-Path -Path $LibreOfficeURL -Leaf
+
 # Define installation paths (adjust as needed)
 $installPathLibreOffice = 'C:\Program Files\LibreOffice'
 
@@ -30,7 +33,7 @@ Set-Location -Path $PSScriptRoot
 # Downloading the LibreOffice installer
 try {
     Write-Log 'Downloading LibreOffice installer...'
-    Invoke-WebRequest -Uri $LibreOfficeURL -OutFile 'LibreOffice_24.8.0_Win_x86-64.msi' -ErrorAction Stop
+    Invoke-WebRequest -Uri $LibreOfficeURL -OutFile $LibreOfficeFILE -ErrorAction Stop
     Write-Log 'LibreOffice installer downloaded successfully.'
 } catch {
     Write-Log "Error downloading LibreOffice installer: $_" "ERROR"
@@ -40,7 +43,7 @@ try {
 # Installing LibreOffice
 try {
     Write-Log 'Installing LibreOffice...'
-    Start-Process 'msiexec.exe' -ArgumentList "/i LibreOffice_24.8.0_Win_x86-64.msi /qn INSTALLDIR=`"$installPathLibreOffice`"" -NoNewWindow -Wait
+    Start-Process 'msiexec.exe' -ArgumentList "/i $LibreOfficeFILE /qn INSTALLDIR=`"$installPathLibreOffice`"" -NoNewWindow -Wait
     Write-Log 'LibreOffice installation initiated.'
 } catch {
     Write-Log "Error starting LibreOffice installation: $_" "ERROR"
@@ -58,7 +61,7 @@ if (Get-Command "$installPathLibreOffice\program\soffice.exe" -ErrorAction Silen
 # Delete the downloaded installer after installation
 try {
     Write-Log 'Deleting LibreOffice installer...'
-    Remove-Item 'LibreOffice_24.8.0_Win_x86-64.msi' -Force -ErrorAction Stop
+    Remove-Item $LibreOfficeFILE -Force -ErrorAction Stop
     Write-Log 'Installer deleted. Installation process is complete.'
 } catch {
     Write-Log "Error deleting LibreOffice installer: $_" "ERROR"

--- a/Libra-Office-Auto-Installer(non admin).ps1
+++ b/Libra-Office-Auto-Installer(non admin).ps1
@@ -1,12 +1,15 @@
 # Define URLs for software installers
 $LibreOfficeURL = 'https://tdf.mirror.garr.it/libreoffice/stable/24.8.0/win/x86_64/LibreOffice_24.8.0_Win_x86-64.msi'
 
+# Store LibreOffice URL basename in variable
+$LibreOfficeFILE = Split-Path -Path $LibreOfficeURL -Leaf
+
 # Define installation paths (adjust as needed)
 $installPathLibreOffice = "$env:USERPROFILE\LibreOffice"
 $logFilePath = "$PSScriptRoot\install_log.txt"
 
 # Function to log messages
-function Log-Message {
+function Write-Log {
     param (
         [string]$message,
         [string]$type = 'INFO'
@@ -20,42 +23,42 @@ function Log-Message {
 # Change working directory to the script's directory
 Set-Location -Path $PSScriptRoot
 
-Log-Message 'Starting LibreOffice installation process.'
+Write-Log 'Starting LibreOffice installation process.'
 
-Log-Message 'Downloading LibreOffice installer...'
+Write-Log 'Downloading LibreOffice installer...'
 
 try {
     # Downloading the LibreOffice installer
-    Invoke-WebRequest -Uri $LibreOfficeURL -OutFile 'LibreOffice_24.8.0_Win_x86-64.msi'
-    Log-Message 'Download completed successfully.'
+    Invoke-WebRequest -Uri $LibreOfficeURL -OutFile $LibreOfficeFILE
+    Write-Log 'Download completed successfully.'
 } catch {
-    Log-Message 'Failed to download the LibreOffice installer.' 'ERROR'
+    Write-Log 'Failed to download the LibreOffice installer.' 'ERROR'
     exit 1
 }
 
-Log-Message 'Installing LibreOffice...'
+Write-Log 'Installing LibreOffice...'
 
 try {
     # Execute the installation file
-    Start-Process 'msiexec.exe' -ArgumentList "/i LibreOffice_24.8.0_Win_x86-64.msi /qn INSTALLDIR=`"$installPathLibreOffice`"" -NoNewWindow -Wait
-    Log-Message 'Installation completed successfully.'
+    Start-Process 'msiexec.exe' -ArgumentList "/i $LibreOfficeFILE /qn INSTALLDIR=`"$installPathLibreOffice`"" -NoNewWindow -Wait
+    Write-Log 'Installation completed successfully.'
 } catch {
-    Log-Message 'Failed to install LibreOffice.' 'ERROR'
+    Write-Log 'Failed to install LibreOffice.' 'ERROR'
     exit 1
 }
 
 # Verify the installation
 if (Test-Path "$installPathLibreOffice\program\soffice.exe") {
-    Log-Message 'LibreOffice installed successfully.'
+    Write-Log 'LibreOffice installed successfully.'
 } else {
-    Log-Message 'LibreOffice installation verification failed.' 'ERROR'
+    Write-Log 'LibreOffice installation verification failed.' 'ERROR'
     exit 1
 }
 
-Log-Message 'Deleting LibreOffice installer...'
+Write-Log 'Deleting LibreOffice installer...'
 try {
-    Remove-Item 'LibreOffice_24.8.0_Win_x86-64.msi' -Force
-    Log-Message 'Installer deleted successfully. Installation process is complete.'
+    Remove-Item $LibreOfficeFILE -Force
+    Write-Log 'Installer deleted successfully. Installation process is complete.'
 } catch {
-    Log-Message 'Failed to delete the LibreOffice installer.' 'ERROR'
+    Write-Log 'Failed to delete the LibreOffice installer.' 'ERROR'
 }


### PR DESCRIPTION
1) Added variable for filename (basename of URL) to both admin and non-admin scripts
Simplifies updating of script to need to only change one line for updated installer URLs

2) changed Log-Message to Write-Log in non-admin script This both makes it match the naming in the admin script and removes the PSScriptAnalyzer warning that Log-Message uses an unapproved verb